### PR TITLE
(BUG) Get wallet address without navigation

### DIFF
--- a/components/connect.js
+++ b/components/connect.js
@@ -1,47 +1,41 @@
-import { useWeb3 } from "@3rdweb/hooks" 
-import { Link } from "../routes";
-import { Card, Button } from "semantic-ui-react";
-
+import { useWeb3 } from "@3rdweb/hooks"
+import { Link } from "../routes"
+import { Card, Button } from "semantic-ui-react"
 
 export default function Connect() {
-
-  const { connectWallet, address, error } = useWeb3();
+  const { connectWallet, address, error } = useWeb3()
 
   return (
-    
-  
-    
-   <div className="flex flex-col items-center justify-center min-h-screen py-2 bg-slate-100">
-    {address ? (
-      // <p className="px-2 py-1 rounded-full bg-gray-200 hover:bg-gray-300 font-mono font-medium cursor-pointer duration-100">
-      //   {address}
-      // </p>
+    <div className="flex flex-col items-center justify-center min-h-screen py-2 bg-slate-100">
+      {address ? (
+        // <p className="px-2 py-1 rounded-full bg-gray-200 hover:bg-gray-300 font-mono font-medium cursor-pointer duration-100">
+        //   {address}
+        // </p>
 
-      <Link route={`/campaigns/${address}/wallet`}>
-
+        <Link route={`/wallet/${address}`}>
           {/* onSelectLanguage={this.handleLanguage} */}
-            <a>
-              <Button
-                floated="right"
-                content=" Show Wallet"
-                icon="add circle"
-                primary
-              />
-            </a>
-          </Link>
-    ) : (
-      <Link route="/campaigns/new">
-      <Button
-      floated="right"
-      content=" Show Wallet"
-      icon="add circle"
-      primary    
-      onClick={()=>connectWallet("injected")}
-      >
-        Connect Wallet
-      </Button>
-       </Link>
-    )}
-  </div>
-);
+          <a>
+            <Button
+              floated="right"
+              content=" Show Wallet"
+              icon="add circle"
+              primary
+            />
+          </a>
+        </Link>
+      ) : (
+        <Link route="/campaigns/new">
+          <Button
+            floated="right"
+            content=" Show Wallet"
+            icon="add circle"
+            primary
+            onClick={() => connectWallet("injected")}
+          >
+            Connect Wallet
+          </Button>
+        </Link>
+      )}
+    </div>
+  )
 }

--- a/pages/campaigns/[address].js
+++ b/pages/campaigns/[address].js
@@ -144,11 +144,9 @@ const CampaignShow = (props) => {
 export default CampaignShow
 
 export async function getServerSideProps(props) {
-  let campaign = await Campaign(
-    props.query.address
-      ? props.query.address
-      : "0x807A21f7D22E1Dba5b878661BD455F0d31D62858"
-  )
+  let contractAddress = props.resolvedUrl.split("/campaigns/")[1]
+
+  let campaign = await Campaign(contractAddress)
 
   let summary = await campaign.methods.getSummary().call()
 

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -48,7 +48,7 @@ class CampaignIndex extends Component {
           "https://i.scdn.co/image/ab6761610000e5ebadd503b411a712e277895c8a",
         // header: address,
         description: (
-          <Link route={`/campaigns/${address}`}>
+          <Link route={`campaigns/${address}`}>
             <div class="row">
               <div class="col-1-of-3">
                 <img

--- a/pages/shows.js
+++ b/pages/shows.js
@@ -1,17 +1,17 @@
-import React, { Component } from "react";
-import { Card, Button, Image } from "semantic-ui-react";
-import factory from "../ethereum/factory";
-import Layout from "../components/Layout";
-import { Link } from "../routes";
-import Connect from "../components/connect";
-import { useWeb3 } from "@3rdweb/hooks";
-import web3 from "../ethereum/web3";
-import CampaignNew from "./campaigns/new";
-import Campaign from "../ethereum/campaign";
+import React, { Component } from "react"
+import { Card, Button, Image } from "semantic-ui-react"
+import factory from "../ethereum/factory"
+import Layout from "../components/Layout"
+import { Link } from "../routes"
+import Connect from "../components/connect"
+import { useWeb3 } from "@3rdweb/hooks"
+import web3 from "../ethereum/web3"
+import CampaignNew from "./campaigns/new"
+import Campaign from "../ethereum/campaign"
 
 class CampaignIndex extends Component {
   static async getInitialProps() {
-    const campaigns = await factory.methods.getDeployedCampaigns().call();
+    const campaigns = await factory.methods.getDeployedCampaigns().call()
 
     // const allCampaigns = await Promise.all(
     //   Array(parseInt(campaigns.length))
@@ -22,26 +22,26 @@ class CampaignIndex extends Component {
     //     })
     // );
 
-    return { campaigns };
+    return { campaigns }
   }
 
   renderRow() {
     return this.props.campaigns.map((oneCampaign) => {
       // let campaign = Campaign(oneCampaign);
-      return campaign.methods.getSummary().call();
-    });
+      return campaign.methods.getSummary().call()
+    })
   }
 
   renderCampaigns() {
     const items = this.props.campaigns.map((address, showName) => {
       async function get() {
-        let campaign = Campaign(address);
-        let oneCampaign = await campaign.methods.getSummary().call();
-        console.log(oneCampaign);
+        let campaign = Campaign(address)
+        let oneCampaign = await campaign.methods.getSummary().call()
+        console.log(oneCampaign)
         // expected output: "resolved"
       }
 
-      get();
+      get()
 
       return {
         Image:
@@ -63,17 +63,12 @@ class CampaignIndex extends Component {
                 <button class="ui primary right floated button buy"></button>
               </div>
             </div>
-            {/* <img
-              class="image"
-              src="https://i.scdn.co/image/ab6761610000e5ebadd503b411a712e277895c8a"
-            ></img> */}
-            {/* <a>View Campaign</a> */}
           </Link>
         ),
         fluid: true,
-      };
-    });
-    return <Card.Group items={items} />;
+      }
+    })
+    return <Card.Group items={items} />
   }
 
   render() {
@@ -100,8 +95,8 @@ class CampaignIndex extends Component {
           </div>
         </div>
       </Layout>
-    );
+    )
   }
 }
 
-export default CampaignIndex;
+export default CampaignIndex

--- a/pages/wallet/[address].js
+++ b/pages/wallet/[address].js
@@ -1,36 +1,36 @@
-import React, { Component, useState } from "react";
-import { Button, Table } from "semantic-ui-react";
-import { Link } from "../../routes";
-import Layout from "../../components/Layout";
-import Campaign from "../../ethereum/campaign";
-import Ticket from "../../ethereum/tickets";
-import TicketRow from "../../components/TicketRow";
-import web3 from "../../ethereum/web3";
-import QRCode from "react-qr-code";
+import React, { Component, useState } from "react"
+import { Button, Table } from "semantic-ui-react"
+import { Link } from "../../routes"
+import Layout from "../../components/Layout"
+import Campaign from "../../ethereum/campaign"
+import Ticket from "../../ethereum/tickets"
+import TicketRow from "../../components/TicketRow"
+import web3 from "../../ethereum/web3"
+import QRCode from "react-qr-code"
 
 class RequestIndex extends Component {
   static async getInitialProps(props) {
     // const [count, setCount] = useState(0);
     const ticketsCount = await Ticket.methods
       .getTicketsCount(props.query.address)
-      .call();
+      .call()
     // const approversCount = await campaign.methods.approversCount().call();
-    const water = "Water";
+    const water = "Water"
     const tickets = await Promise.all(
       Array(parseInt(ticketsCount))
         .fill()
         .map((element, index) => {
-          return Ticket.methods.userTickets(props.query.address, index).call();
+          return Ticket.methods.userTickets(props.query.address, index).call()
         })
-    );
+    )
 
-    return { tickets, ticketsCount, water };
+    return { tickets, ticketsCount, water }
 
     // 0x544aB7D5741863278E85383B933A7e15Cb7e809f
   }
 
   handleClick() {
-    console.log("this is:", this);
+    console.log("this is:", this)
   }
 
   renderRows() {
@@ -53,12 +53,12 @@ class RequestIndex extends Component {
             // approversCount={this.props.approversCount}
           />
         </a>
-      );
-    });
+      )
+    })
   }
 
   render() {
-    const { Header, Row, HeaderCell, Body } = Table;
+    const { Header, Row, HeaderCell, Body } = Table
 
     return (
       <Layout>
@@ -107,8 +107,8 @@ class RequestIndex extends Component {
           </a>
         </div>
       </Layout>
-    );
+    )
   }
 }
 
-export default RequestIndex;
+export default RequestIndex


### PR DESCRIPTION
This was happening because I originally had a pages/show and pages/wallet rather than dynamic campaigns/[address].js and wallet/[address].js, making it much harder for extract the addresses from the URL.
